### PR TITLE
Bump version of linespaces dependency for npm>2.7.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/evanshortiss/lintspaces-cli",
   "dependencies": {
     "commander": "~2.2.0",
-    "lintspaces": "~0.2.1",
+    "lintspaces": "~0.3.0",
     "colors": "~0.6.2"
   }
 }


### PR DESCRIPTION
Basically lintspaces-cli is inheriting these issues from
node-lintspaces:

https://github.com/schorfES/node-lintspaces/pull/15
https://github.com/schorfES/node-lintspaces/issues/16

To have lintspaces-cli work for npm version 2.7.5 or greater, we just
need our minimum dependency on lintspaces to be the one with the fix in
it.