### PR TITLE
Fix RangeError: Invalid string length with Node 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ validator = new Validator({
 
 
 // Get files from args to support **/* syntax. Probably not the best way...
-targetFiles = process.argv.filter(function (f) {
+targetFiles = process.argv.slice(1).filter(function (f) {
   if (f === process.argv[1]) {
     return false;
   } else {


### PR DESCRIPTION
This is the fix discussed in https://github.com/evanshortiss/lintspaces-cli/issues/6.