### PR TITLE
Fix --endofline bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ module.exports = function (process, console) {
     trailingspacesToIgnores: program.trailingspacesToIgnores,
     allowsBOM: program.allowsBOM,
     verbose: program.verbose,
-    endOfLine: program.endOfLine
+    endOfLine: program.endofline
   })
 
   if (!program.args || program.args.length === 0) {


### PR DESCRIPTION
Currently, line endings are not being checked since `program.endOfLine` always is `undefined`.